### PR TITLE
new features: thread_rng, impl_rng_core, and versioned glam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,26 +10,27 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
@@ -39,15 +40,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -63,33 +64,33 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -100,10 +101,14 @@ name = "frand"
 version = "0.8.1"
 dependencies = [
  "fastrand",
- "glam",
+ "glam 0.24.1",
+ "glam 0.25.0",
+ "glam 0.26.0",
+ "glam 0.27.0",
  "hashbrown",
  "image",
  "rand",
+ "rand_core",
  "wyhash",
 ]
 
@@ -125,10 +130,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42218cb640844e3872cc3c153dc975229e080a6c4733b34709ef445610550226"
 
 [[package]]
-name = "hashbrown"
-version = "0.14.0"
+name = "glam"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebe52f2c58f1eea4d6fd3307058cf818c74181435a3620502d1651db07ff018"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -136,14 +159,13 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.6"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "num-rational",
  "num-traits",
  "png",
 ]
@@ -156,55 +178,34 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
  "simd-adler32",
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "png"
-version = "0.17.9"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -218,6 +219,24 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -251,9 +270,26 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "syn"
+version = "2.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
@@ -274,4 +310,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "frand"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "fastrand",
  "glam 0.24.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frand"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["EngusMaze"]
 description = "Blazingly fast random number generation library"
@@ -30,7 +30,7 @@ rand_core = { version = "0.6", optional = true }
 
 [features]
 default = ["glam_027", "std", "alloc", "thread_rng", "impl_rng_core"]
-thread_rng = ["dep:rand"]
+thread_rng = ["dep:rand", "impl_rng_core"]
 impl_rng_core = ["dep:rand_core", "dep:rand"]
 glam_027 = ["dep:glam_027", "glam"]
 glam_026 = ["dep:glam_026", "glam"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,30 @@ exclude = ["*.png"]
 readme = "README.md"
 
 [dev-dependencies]
-hashbrown = "0.14.0"
+hashbrown = "0.14"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
-
+rand = { version = "0.8", features = ["small_rng"] }
 # Other PRNGs
-rand = { version = "0.8.5", features = ["small_rng"] }
+
 fastrand = "2.0.0"
 wyhash = "0.5.0"
 
 [dependencies]
-glam = { version = "0.24.1", optional = true }
+glam_027 = { package = "glam", version = "0.27", optional = true }
+glam_026 = { package = "glam", version = "0.26", optional = true }
+glam_025 = { package = "glam", version = "0.25", optional = true }
+glam_024 = { package = "glam", version = "0.24", optional = true }
+rand = { version = "0.8", features = ["small_rng"], optional = true }
+rand_core = { version = "0.6", optional = true }
 
 [features]
-default = ["glam", "std", "alloc"]
-glam = ["dep:glam"]
+default = ["glam_027", "std", "alloc", "thread_rng", "impl_rng_core"]
+thread_rng = ["dep:rand"]
+impl_rng_core = ["dep:rand_core", "dep:rand"]
+glam_027 = ["dep:glam_027", "glam"]
+glam_026 = ["dep:glam_026", "glam"]
+glam_025 = ["dep:glam_025", "glam"]
+glam_024 = ["dep:glam_024", "glam"]
+glam = []
 std = ["alloc"]
 alloc = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# channel = "stable"
+channel = "nightly"

--- a/src/gen/float.rs
+++ b/src/gen/float.rs
@@ -60,8 +60,14 @@ impl RandomGeneratable for [f64; 2] {
 
 #[cfg(feature = "glam")]
 mod glam_impl {
-    use glam::{Vec2, Vec3, Vec3A, Vec4};
-
+    #[cfg(feature = "glam_027")]
+    pub use glam_027::{Vec2, Vec3, Vec3A, Vec4};
+    #[cfg(feature = "glam_026")]
+    pub use glam_026::{Vec2, Vec3, Vec3A, Vec4};
+    #[cfg(feature = "glam_025")]
+    pub use glam_025::{Vec2, Vec3, Vec3A, Vec4};
+    #[cfg(feature = "glam_024")]
+    pub use glam_025::{Vec2, Vec3, Vec3A, Vec4};
     use super::*;
 
     impl RandomGeneratable for Vec2 {

--- a/src/gen/float.rs
+++ b/src/gen/float.rs
@@ -67,7 +67,7 @@ mod glam_impl {
     #[cfg(feature = "glam_025")]
     pub use glam_025::{Vec2, Vec3, Vec3A, Vec4};
     #[cfg(feature = "glam_024")]
-    pub use glam_025::{Vec2, Vec3, Vec3A, Vec4};
+    pub use glam_024::{Vec2, Vec3, Vec3A, Vec4};
     use super::*;
 
     impl RandomGeneratable for Vec2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,6 @@ println!("{}", rng.gen::<f32>());
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "impl_rng_core")]
-use rand::{RngCore, SeedableRng};
-#[cfg(feature = "impl_rng_core")]
 use rand_core::impls::fill_bytes_via_next;
 #[cfg(feature = "impl_rng_core")]
 pub use rand::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 use rand::{RngCore, SeedableRng};
 #[cfg(feature = "impl_rng_core")]
 use rand_core::impls::fill_bytes_via_next;
+#[cfg(feature = "impl_rng_core")]
+pub use rand::*;
 
 mod gen;
 pub use gen::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,62 @@
+/*!
+**FRand** is a blazingly fast, small, and simple pseudo-random number 
+generator (PRNG) written in Rust. The advantage of using FRand is that 
+it can produce more random numbers per second than other libraries. It 
+also produces high-quality random numbers using a fast 
+**non-cryptographic** hashing algorithm.
+
+# Usage
+
+This crate is [on crates.io](https://crates.io/crates/regex) and can be
+used by adding `regex` to your dependencies in your project's `Cargo.toml`.
+
+```toml
+[dependencies]
+frand = "0.8"
+```
+
+# Example
+
+**FRand** is really simple to use. Here is a simple example of how to 
+use FRand to generate a random float:
+
+```rust
+use frand::Rand;
+
+let mut rng = Rand::new();
+println!("{}", rng.gen::<f32>());
+```
+
+# Crate features
+
+* **std** -
+    (default) Enables the use of the standard library. This feature is 
+    required for the `new` and `rehash` functions.
+* **alloc* -
+    (default) Enables the use of the `alloc` crate. This feature is 
+    required to allow shuffling of Boxes and Vecs.
+* **impl_rng_core** -
+    (default) Enables the implementation of the `rand::RngCore` and 
+    `rand::SeedableRng` traits for the `Rand` struct. This feature is
+    required to use FRand with the `rand` and things like `rand::distributions`.
+* **thread_rng** -
+    (default) Enables the thread local version of FRand. This can be
+    accessed using the `thread_frand` function.
+* **glam_027** -
+    (default) Uses glam version 0.27 to enable the generation of random 
+    values for glam::Vec2, glam::Vec3, glam::Vec3A, and glam::Vec4.
+* **glam_026** -
+    (default) Uses glam version 0.26 to enable the generation of random 
+    values for glam::Vec2, glam::Vec3, glam::Vec3A, and glam::Vec4.
+* **glam_025** -
+    (default) Uses glam version 0.25 to enable the generation of random 
+    values for glam::Vec2, glam::Vec3, glam::Vec3A, and glam::Vec4.
+* **glam_024** -
+    (default) Uses glam version 0.24 to enable the generation of random 
+    values for glam::Vec2, glam::Vec3, glam::Vec3A, and glam::Vec4.        
+
+
+ */
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "impl_rng_core")]

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,0 +1,117 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Thread-local random number generator
+
+use core::cell::UnsafeCell;
+use std::rc::Rc;
+use std::thread_local;
+
+use rand::RngCore;
+
+use crate::{RandomGeneratable, Rand as Frand };
+
+
+
+#[derive(Clone, Debug,)]
+pub struct ThreadFrand {
+    // Rc is explicitly !Send and !Sync
+    rng: Rc<UnsafeCell<Frand>>,
+}
+
+thread_local!(
+    // We require Rc<..> to avoid premature freeing when thread_rng is used
+    // within thread-local destructors. See #968.
+    static THREAD_RNG_KEY: Rc<UnsafeCell<Frand>> = {
+        let rng = Frand::new();
+        Rc::new(UnsafeCell::new(rng))
+    }
+);
+
+
+pub fn thread_randy() -> ThreadFrand {
+    let rng = THREAD_RNG_KEY.with(|t| t.clone());
+    ThreadFrand { rng }
+}
+
+
+
+impl Default for ThreadFrand {
+    fn default() -> ThreadFrand {
+        thread_randy()
+    }
+}
+
+// impl ThreadFrand {
+    
+//     pub fn gen<T>() {
+//         let rng = unsafe { &mut *self.rng.get() };
+//     }
+// }
+
+impl ThreadFrand {
+    /// Mixes the current seed with the provided value.
+    /// This mixing operation is particularly useful in `no_std` environments when you want
+    /// to create a PRNG that incorporates external factors or environmental entropy, such
+    /// as time, to increase randomness.
+    #[inline]
+    pub fn mix(&mut self, value: u64) {
+        (unsafe { &mut *self.rng.get() }).mix(value);
+    }
+
+    /// Rehashes the current Rand instance by creating a new one with a fresh seed.
+    /// This function is only available when the "std" feature is enabled.
+    #[inline]
+    pub fn rehash(&mut self) {
+        (unsafe { &mut *self.rng.get() }).rehash();
+    }
+
+    /// Generates a random value of type T using this Rand instance.
+    /// T must implement the RandomGeneratable trait, which defines how to generate random values.
+    #[inline(always)]
+    pub fn gen<T: RandomGeneratable>(&mut self) -> T {
+        (unsafe { &mut *self.rng.get() }).gen::<T>()
+    }
+}
+
+impl RngCore for ThreadFrand {
+    fn next_u32(&mut self) -> u32 {
+        (unsafe { &mut *self.rng.get() }).gen::<u32>()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        (unsafe { &mut *self.rng.get() }).gen::<u64>()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        (unsafe { &mut *self.rng.get() }).fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        (unsafe { &mut *self.rng.get() }).try_fill_bytes(dest)
+    }
+}
+
+
+
+
+
+#[cfg(test)]
+mod test {
+    use rand::Rng;
+
+    use crate::thread::thread_randy;
+
+    #[test]
+    fn test_thread_rng() {
+
+        let mut r = thread_randy();
+        // r.gen::<i32>();
+        assert_eq!(r.gen_range(0..1), 0);
+    }
+}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -34,7 +34,7 @@ thread_local!(
 );
 
 
-pub fn thread_randy() -> ThreadFrand {
+pub fn thread_frand() -> ThreadFrand {
     let rng = THREAD_RNG_KEY.with(|t| t.clone());
     ThreadFrand { rng }
 }
@@ -43,7 +43,7 @@ pub fn thread_randy() -> ThreadFrand {
 
 impl Default for ThreadFrand {
     fn default() -> ThreadFrand {
-        thread_randy()
+        thread_frand()
     }
 }
 
@@ -105,12 +105,12 @@ impl RngCore for ThreadFrand {
 mod test {
     use rand::Rng;
 
-    use crate::thread::thread_randy;
+    use crate::thread::thread_frand;
 
     #[test]
     fn test_thread_rng() {
 
-        let mut r = thread_randy();
+        let mut r = thread_frand();
         // r.gen::<i32>();
         assert_eq!(r.gen_range(0..1), 0);
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -33,7 +33,7 @@ thread_local!(
     }
 );
 
-
+/// Retrieve the lazily-initialized thread-local random number generator.
 pub fn thread_frand() -> ThreadFrand {
     let rng = THREAD_RNG_KEY.with(|t| t.clone());
     ThreadFrand { rng }
@@ -46,13 +46,6 @@ impl Default for ThreadFrand {
         thread_frand()
     }
 }
-
-// impl ThreadFrand {
-    
-//     pub fn gen<T>() {
-//         let rng = unsafe { &mut *self.rng.get() };
-//     }
-// }
 
 impl ThreadFrand {
     /// Mixes the current seed with the provided value.
@@ -96,9 +89,6 @@ impl RngCore for ThreadFrand {
         (unsafe { &mut *self.rng.get() }).try_fill_bytes(dest)
     }
 }
-
-
-
 
 
 #[cfg(test)]


### PR DESCRIPTION
* thread_rng adds support for thread local random number generation.
* impl_rng_core implements the RngCore and SeedableRng traits from rand.
* You can now choose which version of glam. you wish to use by using the glam_02x feature. 

This pr was created because I wanted to use frand in a bevy game I'm working on, but I needed the thread_rng support.

I was originally going to just for the repo, but I thought I'd clean it up and open a PR to see what you thought.