### PR TITLE
new features: thread_rng, impl_rng_core, and versioned glam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,13 +98,14 @@ dependencies = [
 
 [[package]]
 name = "frand"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "fastrand",
  "glam",
  "hashbrown",
  "image",
  "rand",
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frand"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["EngusMaze"]
 description = "Blazingly fast random number generation library"
@@ -14,15 +14,19 @@ readme = "README.md"
 [dev-dependencies]
 hashbrown = "0.14.5"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
-
+rand = { version = "0.8", features = ["small_rng"] }
 # Other PRNGs
-rand = { version = "0.8.5", features = ["small_rng"] }
+
 fastrand = "2.0.0"
 
 [dependencies]
 glam = { version = "0", optional = true }
+rand = { version = "0.8", features = ["small_rng"], optional = true }
+rand_core = { version = "0.6", optional = true }
 
 [features]
-default = ["glam", "std"]
+default = ["glam", "std", "thread_rng", "impl_rng_core"]
+thread_rng = ["dep:rand", "impl_rng_core"]
+impl_rng_core = ["dep:rand_core", "dep:rand"]
 glam = ["dep:glam"]
 std = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# channel = "stable"
+channel = "nightly"

--- a/src/gen/float.rs
+++ b/src/gen/float.rs
@@ -64,9 +64,8 @@ impl Random for [f64; 2] {
 
 #[cfg(feature = "glam")]
 mod glam_impl {
-    use glam::{Vec2, Vec3, Vec3A, Vec4};
-
-    use super::*;
+    pub use glam::{Vec2, Vec3, Vec3A, Vec4};
+    use crate::{Rand, Random};
 
     impl Random for Vec2 {
         #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl Rand {
     }
 }
 
-
+#[cfg(feature = "impl_rng_core")]
 impl RngCore for Rand {
     fn next_u32(&mut self) -> u32 {
         self.gen::<u32>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,69 @@
+/*!
+**FRand** is a blazingly fast, small, and simple pseudo-random number 
+generator (PRNG) written in Rust. The advantage of using FRand is that 
+it can produce more random numbers per second than other libraries. It 
+also produces high-quality random numbers using a fast 
+**non-cryptographic** hashing algorithm.
+
+# Usage
+
+This crate is [on crates.io](https://crates.io/crates/regex) and can be
+used by adding `regex` to your dependencies in your project's `Cargo.toml`.
+
+```toml
+[dependencies]
+frand = "0.8"
+```
+
+# Example
+
+**FRand** is really simple to use. Here is a simple example of how to 
+use FRand to generate a random float:
+
+```rust
+use frand::Rand;
+
+let mut rng = Rand::new();
+println!("{}", rng.gen::<f32>());
+```
+
+# Crate features
+
+* **std** -
+    (default) Enables the use of the standard library. This feature is 
+    required for the `new` and `rehash` functions.
+* **alloc* -
+    (default) Enables the use of the `alloc` crate. This feature is 
+    required to allow shuffling of Boxes and Vecs.
+* **impl_rng_core** -
+    (default) Enables the implementation of the `rand::RngCore` and 
+    `rand::SeedableRng` traits for the `Rand` struct. This feature is
+    required to use FRand with the `rand` and things like `rand::distributions`.
+* **thread_rng** -
+    (default) Enables the thread local version of FRand. This can be
+    accessed using the `thread_frand` function.
+* **glam** -
+    (default) Uses glam to enable the generation of random values 
+    for glam::Vec2, glam::Vec3, glam::Vec3A, and glam::Vec4.
+
+
+ */
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::{mem::transmute, ops::Range};
 
+#[cfg(feature = "impl_rng_core")]
+use rand_core::impls::fill_bytes_via_next;
+#[cfg(feature = "impl_rng_core")]
+pub use rand::*;
+
 mod gen;
 pub use gen::*;
+
+#[cfg(feature = "thread_rng")]
+mod thread;
+#[cfg(feature = "thread_rng")]
+pub use thread::*;
 
 mod shuffle;
 pub use shuffle::*;
@@ -56,5 +116,38 @@ impl Rand {
     #[inline]
     pub fn rehash(&mut self) {
         *self = Self::new();
+    }
+}
+
+
+impl RngCore for Rand {
+    fn next_u32(&mut self) -> u32 {
+        self.gen::<u32>()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.gen::<u64>()
+    }
+    
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        fill_bytes_via_next(self, dest);
+    }
+    
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "impl_rng_core")]
+impl SeedableRng for Rand {
+    type Seed = [u8; 8];
+
+    fn from_seed(seed: Self::Seed) -> Self {
+        Self::with_seed(u64::from_be_bytes(seed))
+    }
+
+    fn seed_from_u64(state: u64) -> Self {
+        Self::with_seed(state)
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -70,6 +70,10 @@ impl ThreadFrand {
     pub fn gen<T: Random>(&mut self) -> T {
         (unsafe { &mut *self.rng.get() }).gen::<T>()
     }
+
+    pub fn get_rng(&mut self) -> &mut Frand {
+        unsafe { &mut *self.rng.get() }
+    }
 }
 
 impl RngCore for ThreadFrand {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,0 +1,107 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Thread-local random number generator
+
+use core::cell::UnsafeCell;
+use std::rc::Rc;
+use std::thread_local;
+
+use rand::RngCore;
+
+use crate::{Rand as Frand, Random };
+
+
+
+#[derive(Clone, Debug,)]
+pub struct ThreadFrand {
+    // Rc is explicitly !Send and !Sync
+    rng: Rc<UnsafeCell<Frand>>,
+}
+
+thread_local!(
+    // We require Rc<..> to avoid premature freeing when thread_rng is used
+    // within thread-local destructors. See #968.
+    static THREAD_RNG_KEY: Rc<UnsafeCell<Frand>> = {
+        let rng = Frand::new();
+        Rc::new(UnsafeCell::new(rng))
+    }
+);
+
+/// Retrieve the lazily-initialized thread-local random number generator.
+pub fn thread_frand() -> ThreadFrand {
+    let rng = THREAD_RNG_KEY.with(|t| t.clone());
+    ThreadFrand { rng }
+}
+
+
+
+impl Default for ThreadFrand {
+    fn default() -> ThreadFrand {
+        thread_frand()
+    }
+}
+
+impl ThreadFrand {
+    /// Mixes the current seed with the provided value.
+    /// This mixing operation is particularly useful in `no_std` environments when you want
+    /// to create a PRNG that incorporates external factors or environmental entropy, such
+    /// as time, to increase randomness.
+    #[inline]
+    pub fn mix(&mut self, value: u64) {
+        (unsafe { &mut *self.rng.get() }).mix(value);
+    }
+
+    /// Rehashes the current Rand instance by creating a new one with a fresh seed.
+    /// This function is only available when the "std" feature is enabled.
+    #[inline]
+    pub fn rehash(&mut self) {
+        (unsafe { &mut *self.rng.get() }).rehash();
+    }
+
+    /// Generates a random value of type T using this Rand instance.
+    /// T must implement the Random trait, which defines how to generate random values.
+    #[inline(always)]
+    pub fn gen<T: Random>(&mut self) -> T {
+        (unsafe { &mut *self.rng.get() }).gen::<T>()
+    }
+}
+
+impl RngCore for ThreadFrand {
+    fn next_u32(&mut self) -> u32 {
+        (unsafe { &mut *self.rng.get() }).gen::<u32>()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        (unsafe { &mut *self.rng.get() }).gen::<u64>()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        (unsafe { &mut *self.rng.get() }).fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        (unsafe { &mut *self.rng.get() }).try_fill_bytes(dest)
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use rand::Rng;
+
+    use crate::thread::thread_frand;
+
+    #[test]
+    fn test_thread_rng() {
+
+        let mut r = thread_frand();
+        // r.gen::<i32>();
+        assert_eq!(r.gen_range(0..1), 0);
+    }
+}


### PR DESCRIPTION
* thread_rng adds support for thread local random number generation.
* impl_rng_core implements the RngCore and SeedableRng traits from rand.
* You can now choose which version of glam. you wish to use by using the glam_02x feature. 

This pr was created because I wanted to use frand in a bevy game I'm working on, but I needed the thread_rng support.

I was originally going to just fork the repo, but I thought I'd clean it up and open a PR to see what you thought.

I'm open to feedback or modifications, just thought you mind find this useful.